### PR TITLE
Support --dry-run for parameters with spaces or zero length

### DIFF
--- a/run.c
+++ b/run.c
@@ -616,13 +616,37 @@ do_process (struct context *con, JsonNode *rootval)
     }
 }
 
+static char * add_quotes( char  * in )
+{
+  unsigned int len_in = strlen(in);
+  char * ret = malloc(len_in + 3);
+  snprintf(ret, len_in + 3, "\"%s\"", in);
+  return ret;
+}
+
+static char * quote_argv( char * argv, int * to_free )
+{
+  if(strstr(argv, " ") || !strlen(argv))
+  {
+    *to_free = 1;
+    return add_quotes(argv);
+  }
+
+  *to_free = 0;
+  return argv;
+}
+
 static void
 dump_argv (char **argv)
 {
   gboolean first = TRUE;
   while (*argv)
     {
-      g_print ("%s%s", first ? "" : " ", *argv);
+      int to_free = 0;
+      char * tmp_argv = quote_argv(*argv, &to_free);
+      g_print ("%s%s", first ? "" : " ", tmp_argv);
+      if(to_free)
+        free(tmp_argv);
       first = FALSE;
       argv++;
     }


### PR DESCRIPTION
Dear Maintainer,

It appeared to me that --dry-run did not quote arguments when calling 'dump_argv' so that if, for example, an environment variable was empty or contained spaces it was not possible to use the generated command.

Consider:
``` JSON
{
	"ociVersion": "1.0.1-dev",
	"process": {
		"env": [
			"SPACE= a a b",
			"EMPTY="
		]
	}
}
```

This yielded previously:

```
$ ./bwrap-oci --bwrap ../bubblewrap/bwrap --dry-run
../bubblewrap/bwrap --as-pid-1 --die-with-parent --setenv SPACE  a a b --setenv EMPTY  --block-fd FD --sync-fd FD --info-fd FD
```
And now:
```
$ ./bwrap-oci --bwrap ../bubblewrap/bwrap --dry-run
../bubblewrap/bwrap --as-pid-1 --die-with-parent --setenv SPACE " a a b" --setenv EMPTY "" --block-fd FD --sync-fd FD --info-fd FD 
```

It is a relatively ad-hoc solution which could be improved but this solved my issue.

Cheers!