### PR TITLE
bind-mount: support the 'dev' option

### DIFF
--- a/run.c
+++ b/run.c
@@ -478,15 +478,29 @@ do_mounts (struct context *con, JsonNode *rootval)
         {
           const char *sourceval = NULL;
           GVariant *source, *options;
-          gboolean readonly = FALSE;
+          gboolean readonly = FALSE, devices= FALSE;
 
           source = g_variant_lookup_value (variant, "source", G_VARIANT_TYPE_STRING);
           if (! source)
             error (EXIT_FAILURE, 0, "invalid source for bind mount\n");
           sourceval = g_variant_get_string (source, NULL);
           options = g_variant_lookup_value (variant, "options", G_VARIANT_TYPE_ARRAY);
+          devices = find_child_value(options, "dev");
           readonly = find_child_value (options, "ro");
-          collect_options (con, readonly ? "--ro-bind" : "--bind", sourceval, destinationval, NULL);
+
+          if( devices && readonly )
+          {
+            error (0, 0, "warning: bind mounts with both 'dev'"
+                         " and 'ro' option are not supported."
+                         " 'dev' option ignored.");
+                         devices= FALSE;
+          }
+
+          collect_options (con, devices?
+                                ("--dev-bind"):(readonly ?
+                                                "--ro-bind" : "--bind"),
+                                sourceval,
+                                destinationval, NULL);
         }
     }
 


### PR DESCRIPTION
Dear Maintainer,

I've encountered a case where I was trying to access an Infiniband card from a container but I always ended-up with mounts with _nodev_ option. After some lookup, I've realized that bubblewrap had the **--dev-bind** option but it was never generated by bwrap-oci.

The enclosed pull-requests proposes to address this by parsing the "dev" option in mounts. However, if **ro** is present we fallback to the previous behavior (except with a warning) as we would not like to change a Read-Only mount to a Read-Write one (as **--dev-bind** is RW).

```
{
            "source": "/dev/infiniband/",
            "destination": "/dev/infiniband/",
            "type": "bind",
            "options": [
                "dev"
            ]
  }
```

Yielded before:
``` bash
$ mount | grep infiniband
devtmpfs on /dev/infiniband type devtmpfs (rw,nosuid,nodev,size=13630556k,nr_inodes=3407639,mode=755)
```

And now 'dev" is correctly handled:

``` bash
$ mount | grep infiniband
devtmpfs on /dev/infiniband type devtmpfs (rw,nosuid,size=13630556k,nr_inodes=3407639,mode=755)
```
Thanks!

Jean-Baptiste.
