### PR TITLE
bwrap-oci: fix musl build

### DIFF
--- a/bwrap-oci.c
+++ b/bwrap-oci.c
@@ -19,7 +19,9 @@
 #include <config.h>
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef HAVE_ERROR_H
 #include <error.h>
+#endif
 #include <stdio.h>
 #include <glib.h>
 #include <glib-object.h>

--- a/configure.ac
+++ b/configure.ac
@@ -18,10 +18,32 @@ PKG_CHECK_MODULES(JSON_GLIB, [json-glib-1.0])
 PKG_CHECK_MODULES(GIO_UNIX, [gio-unix-2.0])
 AC_CHECK_LIB(seccomp, seccomp_rule_add)
 
+AC_CHECK_HEADERS([error.h])
+
 AC_PATH_PROG(BWRAP, [bwrap])
 AC_DEFINE_UNQUOTED([BWRAP], ["$BWRAP"], [Path to bwrap])
 
 AC_CONFIG_FILES([
 Makefile
+])
+
+AH_BOTTOM([
+#ifndef HAVE_ERROR_H
+#ifndef _ERROR_LOCAL
+#define _ERROR_LOCAL 1
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void error(int status, int errnum, const char *msg, ...) {
+	if (errnum)
+		fprintf(stderr, ": %s\n", strerror(errnum));
+	else
+		fputc('\n', stderr);
+	if (status)
+		exit(status);
+}
+#endif
+#endif
 ])
 AC_OUTPUT

--- a/kill.c
+++ b/kill.c
@@ -19,7 +19,9 @@
 #include <config.h>
 #include "util.h"
 #include "kill.h"
+#ifdef HAVE_ERROR_H
 #include <error.h>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 

--- a/list.c
+++ b/list.c
@@ -19,7 +19,9 @@
 #include <config.h>
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef HAVE_ERROR_H
 #include <error.h>
+#endif
 #include <stdio.h>
 #include <glib.h>
 #include <glib-object.h>

--- a/run.c
+++ b/run.c
@@ -19,7 +19,9 @@
 #include <config.h>
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef HAVE_ERROR_H
 #include <error.h>
+#endif
 #include <stdio.h>
 #include <glib.h>
 #include <glib-object.h>

--- a/util.c
+++ b/util.c
@@ -20,7 +20,9 @@
 #include "util.h"
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef HAVE_ERROR_H
 #include <error.h>
+#endif
 #include <stdio.h>
 #include <glib.h>
 #include <glib-object.h>
@@ -369,7 +371,7 @@ get_bundle_path (const char *rootfs)
 {
   gchar *ret;
   cleanup_free gchar *tmp = g_strdup (rootfs);
-  ret = canonicalize_file_name(dirname (tmp));
+  ret = realpath(dirname (tmp), NULL);
   return ret;
 }
 


### PR DESCRIPTION
Imported from Alpine Linux.

- Guard against error.h existence (GLibc specific)
- define error() when error.h doesn't exist
- replace canonicalize_file_name (glibc) with realpath (posix)